### PR TITLE
Potential fix for the BufferError causing the GitHub Unit Tests to fail

### DIFF
--- a/python/vast/voidfinder/_voidfinder.py
+++ b/python/vast/voidfinder/_voidfinder.py
@@ -431,9 +431,9 @@ def _hole_finder(galaxy_coords,
         
             galaxy_map_grid_edge_length = 3.0*hole_grid_edge_length
         
-        coords_max = np.max(galaxy_coords, axis=0)
+        coords_max = np.max(np.concatenate(galaxy_coords), axis=0)
     
-        coords_min = np.min(galaxy_coords, axis=0)
+        coords_min = np.min(np.concatenate(galaxy_coords), axis=0)
         
         box = coords_max - coords_min
     
@@ -528,6 +528,7 @@ def _hole_finder(galaxy_coords,
         
     coords_min = coords_min.reshape(1,3).astype(np.float64)
     
+    galaxy_coords = galaxy_coords[0] #Only use wall galaxies from here on out
     
     if verbose > 0:
         

--- a/python/vast/voidfinder/_voidfinder.py
+++ b/python/vast/voidfinder/_voidfinder.py
@@ -431,9 +431,9 @@ def _hole_finder(galaxy_coords,
         
             galaxy_map_grid_edge_length = 3.0*hole_grid_edge_length
         
-        coords_max = np.max(np.concatenate(galaxy_coords), axis=0)
+        coords_max = np.max(galaxy_coords, axis=0)
     
-        coords_min = np.min(np.concatenate(galaxy_coords), axis=0)
+        coords_min = np.min(galaxy_coords, axis=0)
         
         box = coords_max - coords_min
     
@@ -527,8 +527,6 @@ def _hole_finder(galaxy_coords,
         
         
     coords_min = coords_min.reshape(1,3).astype(np.float64)
-    
-    galaxy_coords = galaxy_coords[0] #Only use wall galaxies from here on out
     
     if verbose > 0:
         

--- a/python/vast/voidfinder/_voidfinder.py
+++ b/python/vast/voidfinder/_voidfinder.py
@@ -1699,7 +1699,11 @@ def _hole_finder(galaxy_coords,
     #
     # Also close all our other mem-maps.
     #---------------------------------------------------------------------------
-    result_buffer.close()
+    #result_buffer.close()
+    # Commented this out due to:
+    # BufferError: cannot close exported pointers exist.
+    # https://stackoverflow.com/questions/53339931/properly-discarding-ctypes-pointers-to-mmap-memory-in-python
+    # https://github.com/ercius/openNCEM/issues/39
     
     # Since the worker function closes this stuff too, we only have to close
     # our parent copies if we're running multi-processed

--- a/python/vast/voidfinder/_voidfinder_cython_find_next.pxd
+++ b/python/vast/voidfinder/_voidfinder_cython_find_next.pxd
@@ -115,6 +115,8 @@ cdef class HoleGridCustomDict:
     
     cdef public HOLE_LOOKUPMEM_t[:] lookup_memory
     
+    cdef public object dummy_arr
+    
     cdef public DTYPE_INT64_t num_collisions
     
     cdef public DTYPE_INT64_t mem_length
@@ -149,6 +151,8 @@ cdef class GalaxyMapCustomDict:
     cdef DTYPE_INT64_t i_dim, j_dim, k_dim, jk_mod, lookup_fd, process_local_num_elements
     
     cdef public LOOKUPMEM_t[:] lookup_memory
+    
+    cdef public object dummy_arr
     
     cdef public DTYPE_INT64_t num_collisions
     

--- a/python/vast/voidfinder/_voidfinder_cython_find_next.pyx
+++ b/python/vast/voidfinder/_voidfinder_cython_find_next.pyx
@@ -2207,10 +2207,18 @@ cdef class GalaxyMap:
     def close(self):
         
         #self.wall_galaxy_buffer.close()
+        # Commented this out due to:
+        # BufferError: cannot close exported pointers exist.
+        # https://stackoverflow.com/questions/53339931/properly-discarding-ctypes-pointers-to-mmap-memory-in-python
+        # https://github.com/ercius/openNCEM/issues/39
         
         os.close(self.wall_galaxies_coords_fd)
         
         #self.galaxy_map_array_buffer.close()
+        # Commented this out due to:
+        # BufferError: cannot close exported pointers exist.
+        # https://stackoverflow.com/questions/53339931/properly-discarding-ctypes-pointers-to-mmap-memory-in-python
+        # https://github.com/ercius/openNCEM/issues/39
         
         os.close(self.gma_fd)
         

--- a/python/vast/voidfinder/_voidfinder_cython_find_next.pyx
+++ b/python/vast/voidfinder/_voidfinder_cython_find_next.pyx
@@ -1164,6 +1164,12 @@ cdef class HoleGridCustomDict:
 
     def close(self):
         
+        self.lookup_memory = self.dummy_arr #Point this to the dummy array so hopefully it
+                                            #releases the actual mmap'd memory
+                                            # BufferError: cannot close exported pointers exist.
+                                            # https://stackoverflow.com/questions/53339931/properly-discarding-ctypes-pointers-to-mmap-memory-in-python
+                                            # https://github.com/ercius/openNCEM/issues/39
+        
         self.hole_lookup_buffer.close()
         
         #print("Closing file descriptor: ", self.lookup_fd, flush=True)
@@ -1617,6 +1623,12 @@ cdef class GalaxyMapCustomDict:
 
 
     def close(self):
+        
+        self.lookup_memory = self.dummy_arr #Point this to the dummy array so hopefully it
+                                            #releases the actual mmap'd memory
+                                            # BufferError: cannot close exported pointers exist.
+                                            # https://stackoverflow.com/questions/53339931/properly-discarding-ctypes-pointers-to-mmap-memory-in-python
+                                            # https://github.com/ercius/openNCEM/issues/39
         
         self.lookup_buffer.close()
         

--- a/python/vast/voidfinder/_voidfinder_cython_find_next.pyx
+++ b/python/vast/voidfinder/_voidfinder_cython_find_next.pyx
@@ -2206,11 +2206,11 @@ cdef class GalaxyMap:
         
     def close(self):
         
-        self.wall_galaxy_buffer.close()
+        #self.wall_galaxy_buffer.close()
         
         os.close(self.wall_galaxies_coords_fd)
         
-        self.galaxy_map_array_buffer.close()
+        #self.galaxy_map_array_buffer.close()
         
         os.close(self.gma_fd)
         


### PR DESCRIPTION
Based on Hernon's findings here:
https://github.com/hbrincon/VAST/runs/8043325424?check_suite_focus=true&fbclid=IwAR22fY_NHNEZBAvM0lsDVXXwt1d9y_senM1w5vp1kkbKx6lZW3IQ7CWooxw

Issue with unit tests failing for Py3.8 and Py3.9 appear to be due Python itself not allowing us to call the close() method on a mem-map we have created (a sort of unnecessary safety check Python is imposing on us...) because we are pointing to that map with one of the class attributes, so even though we're going to immediately re-point that class attribute to the new memory we're about to use, for a brief moment Python thinks we're going to leave it pointing to bad memory and is throwing this BufferError on us.  

This PR contains a fix for this - unfortunately I could not implement the fixes located here:
https://stackoverflow.com/questions/53339931/properly-discarding-ctypes-pointers-to-mmap-memory-in-python
or here:
https://github.com/ercius/openNCEM/issues/39

1). because the Cython memoryview object does not actually have a "release()" method
2). The object containing the pointer is not a regular python object, so calling "del curr_arr" did not work either
3). I also could not explicitly call __dealloc__ (though potentially could revisit this maybe if we 'cimport' the actual memoryview class?)

So to circumvent this issue, I'm implicitly relying on the internal cython memoryview machinery and hoping the cython guys got it right - instead of calling release() or close() or 'del' on the memoryview containing the pointer, I am now creating a very small dummy array, pointing the offending memoryview to the dummy array, THEN closing the memmap and re-pointing the memoryview to that memory.  
