### PR TITLE
Numpy bool fix

### DIFF
--- a/python/vast/voidfinder/viz/neighborize.pyx
+++ b/python/vast/voidfinder/viz/neighborize.pyx
@@ -86,7 +86,7 @@ cpdef list build_grouped_neighbor_index(neighbor_tree, #need int64 types
         
         curr_num_neighbors = <ITYPE_t>curr_neighbors.shape[0]
         
-        valid_idx = np.ones(curr_num_neighbors, dtype=np.bool)
+        valid_idx = np.ones(curr_num_neighbors, dtype=np.bool_)
         
         for jdx in range(curr_num_neighbors):
             

--- a/python/vast/voidfinder/viz/void_render.py
+++ b/python/vast/voidfinder/viz/void_render.py
@@ -1618,7 +1618,7 @@ class VoidRender(app.Canvas):
         
         hole_kdtree = neighbors.KDTree(self.holes_xyz)
         
-        valid_idx = np.ones(self.holes_xyz.shape[0], dtype=np.bool)
+        valid_idx = np.ones(self.holes_xyz.shape[0], dtype=np.bool_)
         
         for curr_idx, (hole_xyz, hole_radius) in enumerate(zip(self.holes_xyz, self.holes_radii)):
             

--- a/python/vast/voidfinder/volume_cut.py
+++ b/python/vast/voidfinder/volume_cut.py
@@ -1081,7 +1081,7 @@ def oob_cut_multi(x_y_z_r_array,
     # DONE
     ############################################################################
         
-    return valid_index.astype(np.bool), monte_index.astype(np.bool)
+    return valid_index.astype(np.bool_), monte_index.astype(np.bool_)
 
 
 


### PR DESCRIPTION
Minor changes for newer Python 3 version where 'numpy.bool' is deprecated and needs to be replaced with regular old python 'bool' or 'numpy.bool_'