### PR TITLE
Save galaxies optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 Log of changes for VAST versions.
 
+### 1.7.3
+- Updated VoidFinder to allow option for not saving galaxies to void-finding output
+
 ### 1.7.2
 - Updated void catalog class to let users search for the void membership of custom coordinates,
   along with small bug fixes

--- a/python/vast/_version.py
+++ b/python/vast/_version.py
@@ -15,5 +15,5 @@ Additional labels for pre-release and build metadata are available as extensions
 
 """
 
-__version__ = '1.7.1'
+__version__ = '1.7.3'
 

--- a/python/vast/voidfinder/_version.py
+++ b/python/vast/voidfinder/_version.py
@@ -16,4 +16,4 @@ Additional labels for pre-release and build metadata are available as extensions
 
 
 
-__version__ = '1.7.1'
+__version__ = '1.7.3'

--- a/python/vast/voidfinder/postprocessing.py
+++ b/python/vast/voidfinder/postprocessing.py
@@ -543,6 +543,7 @@ def save_output_from_find_voids(
         num_cpus,
         batch_size,
         capitalize_colnames,
+        save_missing_galaxies,
         verbose=0):
     
     '''
@@ -646,6 +647,11 @@ def save_output_from_find_voids(
     capitalize_colnames : bool
         If True, the column names in the void table outputs are capitalized. 
         Otherwise, the column names are lowercase
+
+    save_missing_galaxies : bool
+        If True, and if the galaxies have not been previosly saved to the output 
+        file during the the galaxy filtering stage, then galaxy input is saved 
+        to the output
         
     verbose : int or bool
         Level of verbosity to print during running, 0 indicates off, 1 indicates 
@@ -691,12 +697,14 @@ def save_output_from_find_voids(
     try:
         hdul.index_of('FIELD')
     except:
+        wall_galaxies = galaxy_coords_xyz if save_missing_galaxies else np.array([])
+
         append_wall_field_galaxies(
             hdul,   
-            galaxy_coords_xyz, 
+            wall_galaxies, 
             np.array([]),
             capitalize_colnames)
-
+        
     primaryHDU = hdul['PRIMARY']
     wallHDU = hdul['WALL']
     fieldHDU=hdul['FIELD']
@@ -725,7 +733,7 @@ def save_output_from_find_voids(
     primaryHDU.header['WALLNUM'] = (wallHDU.header['WALLNUM'], 'Wall Galaxy Count')
     primaryHDU.header['FIELDNUM'] = (fieldHDU.header['FIELDNUM'], 'Field Galaxy Count')
     primaryHDU.header['DENSITY'] = (mknum(num_gals/vol), 'Galaxy Count Density (Mpc/h)^-3')
-    primaryHDU.header['AVSEP'] = (mknum(np.power(vol/num_gals, 1/3)), 'Average Galaxy Separation (Mpc/h)')
+    if num_gals > 0: primaryHDU.header['AVSEP'] = (mknum(np.power(vol/num_gals, 1/3)), 'Average Galaxy Separation (Mpc/h)')
     primaryHDU.header['VOID'] = (maximalHDU.header['VOID'], 'Void Count')
     if dist_limits is not None:
         primaryHDU.header['DLIML'] = (mknum(dist_limits[0]), 'Lower Distance Limit (Mpc/h)')

--- a/python/vast/voidfinder/postprocessing.py
+++ b/python/vast/voidfinder/postprocessing.py
@@ -649,7 +649,7 @@ def save_output_from_find_voids(
         Otherwise, the column names are lowercase
 
     save_missing_galaxies : bool
-        If True, and if the galaxies have not been previosly saved to the output 
+        If True, and if the galaxies have not been previously saved to the output 
         file during the the galaxy filtering stage, then galaxy input is saved 
         to the output
         

--- a/python/vast/voidfinder/postprocessing.py
+++ b/python/vast/voidfinder/postprocessing.py
@@ -733,7 +733,8 @@ def save_output_from_find_voids(
     primaryHDU.header['WALLNUM'] = (wallHDU.header['WALLNUM'], 'Wall Galaxy Count')
     primaryHDU.header['FIELDNUM'] = (fieldHDU.header['FIELDNUM'], 'Field Galaxy Count')
     primaryHDU.header['DENSITY'] = (mknum(num_gals/vol), 'Galaxy Count Density (Mpc/h)^-3')
-    if num_gals > 0: primaryHDU.header['AVSEP'] = (mknum(np.power(vol/num_gals, 1/3)), 'Average Galaxy Separation (Mpc/h)')
+    if num_gals > 0: 
+        primaryHDU.header['AVSEP'] = (mknum(np.power(vol/num_gals, 1/3)), 'Average Galaxy Separation (Mpc/h)')
     primaryHDU.header['VOID'] = (maximalHDU.header['VOID'], 'Void Count')
     if dist_limits is not None:
         primaryHDU.header['DLIML'] = (mknum(dist_limits[0]), 'Lower Distance Limit (Mpc/h)')

--- a/python/vast/voidfinder/voidfinder.py
+++ b/python/vast/voidfinder/voidfinder.py
@@ -789,6 +789,7 @@ def find_voids(galaxy_coords_xyz,
                verbose=0,
                print_after=5.0,
                capitalize_colnames = False,
+               save_missing_galaxies = True,
                ):
     """
     Main entry point for VoidFinder.  
@@ -1013,6 +1014,11 @@ def find_voids(galaxy_coords_xyz,
     capitalize_colnames : bool
         If True, the column names in the void table outputs are capitalized. 
         Otherwise, the column names are lowercase
+
+    save_missing_galaxies : bool
+        If True, and if the galaxies have not been previosly saved to the output 
+        file during the the galaxy filtering stage, then galaxy input is saved 
+        to the output
     
     
     Returns
@@ -1262,6 +1268,7 @@ def find_voids(galaxy_coords_xyz,
         num_cpus,
         batch_size,
         capitalize_colnames,
+        save_missing_galaxies,
         verbose=verbose
     )
     

--- a/python/vast/voidfinder/voidfinder.py
+++ b/python/vast/voidfinder/voidfinder.py
@@ -1016,7 +1016,7 @@ def find_voids(galaxy_coords_xyz,
         Otherwise, the column names are lowercase
 
     save_missing_galaxies : bool
-        If True, and if the galaxies have not been previosly saved to the output 
+        If True, and if the galaxies have not been previously saved to the output 
         file during the the galaxy filtering stage, then galaxy input is saved 
         to the output
     


### PR DESCRIPTION
Previously, VoidFinder always saved at least the wall galaxies input to the void-finding output file. There is now an option to save none of the galaxies to the output with the `save_missing_galaxies` flag.

```
save_missing_galaxies : bool
         If True, and if the galaxies have not been previously saved to the output 
         file during the the galaxy filtering stage, then galaxy input is saved 
         to the output
```