### PR TITLE
edge buffer bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 Log of changes for VAST versions.
 
 =======
+### 1.7.8
+- Bug fix for edge buffer in VoidCatalog class.
 ### 1.7.7
 - Parallelized Voronoi tessellation for V2. Bug fix for V2 ellipsoid calculations.
 ### 1.7.6

--- a/python/vast/_version.py
+++ b/python/vast/_version.py
@@ -15,5 +15,5 @@ Additional labels for pre-release and build metadata are available as extensions
 
 """
 
-__version__ = '1.7.7'
+__version__ = '1.7.8'
 

--- a/python/vast/catalog/_version.py
+++ b/python/vast/catalog/_version.py
@@ -14,4 +14,4 @@ Additional labels for pre-release and build metadata are available as extensions
 
 """
 
-__version__ = '1.7.7'
+__version__ = '1.7.8'

--- a/python/vast/catalog/void_catalog.py
+++ b/python/vast/catalog/void_catalog.py
@@ -471,7 +471,7 @@ class VoidFinderCatalog (VoidCatalog):
 
             if self.edge_buffer <= 0:
 
-                maximals = self.maximals[points_boolean]
+                maximals = self.maximals
 
             else:
             

--- a/python/vast/catalog/void_catalog.py
+++ b/python/vast/catalog/void_catalog.py
@@ -468,24 +468,30 @@ class VoidFinderCatalog (VoidCatalog):
         print(len(self.maximals[edge==0]),'interior voids')
         
         if np.prod(np.isin(['r_eff','r_eff_uncert'], self.maximals.colnames)) > 0:
+
+            if self.edge_buffer <= 0:
+
+                maximals = self.maximals[points_boolean]
+
+            else:
             
-            points_boolean = np.zeros(len(self.maximals), dtype = bool)
-            
-            mask = self.mask
-            mask_res = self.mask_info['MSKRES']
-            rmin = self.info['DLIML']
-            rmax = self.info['DLIMU']
-
-            #Remove voids near the survey edges
-            for i in range(len(self.maximals)):
-                # The current point
-                curr_pt = self.maximals[i]
-
-                is_edge = vo.is_edge_point(curr_pt['x'], curr_pt['y'], curr_pt['z'],
-                                           mask, mask_res, rmin, rmax, self.edge_buffer)
-                points_boolean[i] = not is_edge
-
-            maximals = self.maximals[points_boolean]
+                points_boolean = np.zeros(len(self.maximals), dtype = bool)
+                
+                mask = self.mask
+                mask_res = self.mask_info['MSKRES']
+                rmin = self.info['DLIML']
+                rmax = self.info['DLIMU']
+    
+                #Remove voids near the survey edges
+                for i in range(len(self.maximals)):
+                    # The current point
+                    curr_pt = self.maximals[i]
+    
+                    is_edge = vo.is_edge_point(curr_pt['x'], curr_pt['y'], curr_pt['z'],
+                                               mask, mask_res, rmin, rmax, self.edge_buffer)
+                    points_boolean[i] = not is_edge
+    
+                maximals = self.maximals[points_boolean]
             
             edge = maximals['edge']
             print(len(maximals[edge==1]),'edge voids (V. Fid)')
@@ -973,12 +979,10 @@ class V2Catalog(VoidCatalog):
         
     """def add_mask(self, voidfinder_cat):
         #copy over ask info from a voidfinder catalog
-        # This function exists because V2 doen'st save masks. In future work, V2 should
+        # This function exists because V2 doesn't save masks. In future work, V2 should
         # just create a mask when it runs
         self.mask_info = voidfinder_cat.mask_info
         self.mask = voidfinder_cat.mask
-        # This is a workaround for me mistakenly running VF and V2 with different redshift limits
-        # In future work, this should be removed, and the catalogs should have the same redshift limits
         self.mask_info['DLIML'] = voidfinder_cat.info['DLIML']
         self.mask_info['DLIMU'] = voidfinder_cat.info['DLIMU']"""
     
@@ -1056,24 +1060,30 @@ class V2Catalog(VoidCatalog):
             edge = edge_area/tot_area > 0.1
             print(len(self.voids[edge]),'edge voids')
             print(len(self.voids[~edge]),'interior voids')
+
+        if self.edge_buffer <= 0:
+
+            voids = self.voids
+
+        else:
             
-        points_boolean = np.zeros(len(self.voids), dtype = bool)
-
-        mask = self.mask
-        mask_res = self.mask_info['MSKRES']
-        rmin = self.info['DLIML']
-        rmax = self.info['DLIMU']
-
-        #Remove voids near the survey edges
-        for i in range(len(self.voids)):
-            # The current point
-            curr_pt = self.voids[i]
-
-            is_edge = vo.is_edge_point(curr_pt['x'], curr_pt['y'], curr_pt['z'],
-                                       mask, mask_res, rmin, rmax, self.edge_buffer)
-            points_boolean[i] = not is_edge
-
-        voids = self.voids[points_boolean]
+            points_boolean = np.zeros(len(self.voids), dtype = bool)
+    
+            mask = self.mask
+            mask_res = self.mask_info['MSKRES']
+            rmin = self.info['DLIML']
+            rmax = self.info['DLIMU']
+    
+            #Remove voids near the survey edges
+            for i in range(len(self.voids)):
+                # The current point
+                curr_pt = self.voids[i]
+    
+                is_edge = vo.is_edge_point(curr_pt['x'], curr_pt['y'], curr_pt['z'],
+                                           mask, mask_res, rmin, rmax, self.edge_buffer)
+                points_boolean[i] = not is_edge
+    
+            voids = self.voids[points_boolean]
         
         if np.prod(np.isin(['tot_area','edge_area'], self.voids.colnames))>0:
             edge_area = voids['edge_area']
@@ -1142,8 +1152,8 @@ class V2Catalog(VoidCatalog):
             #This should never be the case (in current draft of code)
             raise AttributeError('V2 galaxy membership should have a custom mask to accurately exclude edge galaxies')
 
-        
-        vflag = self._check_coords_in_void(galaxies, mask, mask_res, rmin, rmax, edge_threshold=self.edge_buffer, flag_void_near_edge=True)
+        # We set flag_void_near_edge to True because we only want to select galaxies within self.edge_buffer of the survey boundaries
+        vflag = self._check_coords_in_void(galaxies, mask, mask_res, rmin, rmax, edge_threshold = self.edge_buffer, flag_void_near_edge=True)
 
         if return_selector:
             select_void_galaxies = np.isin(self.galaxies['gal'], galaxies['gal'][vflag==1])
@@ -1247,8 +1257,8 @@ class V2Catalog(VoidCatalog):
             rmin = self.info['DLIML']
             rmax = self.info['DLIMU']
 
-        vflag = self._check_coords_in_void(coordinates, mask, mask_res, rmin, rmax, edge_threshold=10)
-        vflag[vflag==-1]=1 # mark coordinates in voids + near edge as simply being in voids
+        # We set edge_threshold to 10 Mpc/h to match the VoidFinder definition (vast.voidfinder.vflag)
+        vflag = self._check_coords_in_void(coordinates, mask, mask_res, rmin, rmax, edge_threshold=10, flag_void_near_edge=False)
         return vflag
 
     def _check_coords_in_void(self, coordinates, mask, mask_res, rmin, rmax, edge_threshold=10, flag_void_near_edge = False):
@@ -1381,8 +1391,8 @@ class V2Catalog(VoidCatalog):
         #mark void galaxies
         self.galaxies['vflag'][selector] = 1"""
 
-        vflag = self._check_coords_in_void(galaxies, mask, mask_res, rmin, rmax, edge_threshold=10)
-        vflag[vflag==-1]=1 # mark coordinates in voids + near edge as simply being in voids
+        # We set edge_theshold to 10 Mpc/h to match the voidfinder definition (vast.voidfinder.vflag)
+        vflag = self._check_coords_in_void(galaxies, mask, mask_res, rmin, rmax, edge_threshold=10, flag_void_near_edge=False)
         self.galaxies['vflag'] = vflag
             
         # Write output to the catalog object
@@ -1615,7 +1625,8 @@ class VoidFinderCatalogStacked (VoidCatalogStacked):
             contruct the void catalog locations if file_names is set to None. Defaults to None.
 
         directory (string): The directories in which the void catalogs are located. Used to contruct 
-            the void catalog locations if file_namse is set to None. Defaults to './'.
+            the void catalog locations if file_names is set to None. Defaults to './'. May also be 
+            set to a list of strings if the void catalogs are stored in different directories.
 
         edge_buffer (float): The distance from the survey boundaries to cut on before performing all
             analysis. This volume cut defines an interior volume V_fid within which void properietes 
@@ -1625,12 +1636,17 @@ class VoidFinderCatalogStacked (VoidCatalogStacked):
         super().__init__(edge_buffer)
          
         if file_names is None:
-            file_names = [directory + name + '_VoidFinder_Output.fits' for name in survey_names]
+            # single directory
+            if isinstance(directory, str):
+                file_names = [directory + name + '_VoidFinder_Output.fits' for name in survey_names]
+            # multiple directories
+            else:
+                file_names = [dir_i + name + '_VoidFinder_Output.fits' for dir_i, name in zip(directory, survey_names)]
                     
         self._catalogs = {}
         
         for cat_name, file_name in zip(cat_names, file_names):
-            self._catalogs[cat_name] = VoidFinderCatalog(file_name)
+            self._catalogs[cat_name] = VoidFinderCatalog(file_name, edge_buffer=edge_buffer)
     
             
     def void_stats(self, report_individual=True):
@@ -1646,6 +1662,9 @@ class VoidFinderCatalogStacked (VoidCatalogStacked):
         """
         
         def filter_maximals(catalog):
+
+            if self.edge_buffer <= 0:
+                return catalog.maximals
             
             points_boolean = np.zeros(len(catalog.maximals), dtype = bool)
             
@@ -1738,7 +1757,8 @@ class V2CatalogStacked (VoidCatalogStacked):
             contruct the void catalog locations if file_names is set to None. Defaults to 'VIDE'.
 
         directory (string): The directories in which the void catalogs are located. Used to contruct 
-            the void catalog locations if file_namse is set to None. Defaults to './'.
+            the void catalog locations if file_names is set to None. Defaults to './'. May also be 
+            set to a list of strings if the void catalogs are stored in different directories.
 
         edge_buffer (float): The distance from the survey boundaries to cut on before performing all
             analysis. This volume cut defines an interior volume V_fid within which void properietes 
@@ -1749,14 +1769,17 @@ class V2CatalogStacked (VoidCatalogStacked):
         
         #format file names
         if file_names is None:
-            file_names = [directory + name + f'_V2_{pruning}_Output.fits' for name in survey_names]
+            # single directory
+            if isinstance(directory, str):
+                file_names = [directory + name + f'_V2_{pruning}_Output.fits' for name in survey_names]
+            else:
+                file_names = [dir_i + name + f'_V2_{pruning}_Output.fits' for dir_i, name in zip(directory, survey_names)]
              
         self._catalogs = {}
         
         for cat_name, file_name in zip(cat_names, file_names):
-            self._catalogs[cat_name] = V2Catalog(file_name)
-        
-            
+            self._catalogs[cat_name] = V2Catalog(file_name, edge_buffer=edge_buffer)
+    
     """def add_mask(self, voidfinder_cat_stacked):
         
         for cat in self._catalogs:
@@ -1778,6 +1801,9 @@ class V2CatalogStacked (VoidCatalogStacked):
             super().void_stats()
             
         def filter_voids(catalog):
+
+            if self.edge_buffer <= 0:
+                return catalog.voids
             
             points_boolean = np.zeros(len(catalog.voids), dtype = bool)
 


### PR DESCRIPTION
The edge_buffer user input for the VoidFinderCatalogStacked and V2CatalogStacked classes were being mistakenly overwritten with a default value of 30 Mpc/h for each VoidFinderCatalog and V2Catalog class contained within them. This bug has been fixed so that the user input is passed between classes.

Also includes a few user-convenience features and speedups for the void_catalog classes